### PR TITLE
Add redis publish to channel

### DIFF
--- a/src/main/java/storm/RedisAverageQueryBolt.java
+++ b/src/main/java/storm/RedisAverageQueryBolt.java
@@ -1,9 +1,5 @@
 package storm;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 import org.apache.storm.redis.bolt.AbstractRedisBolt;
 import org.apache.storm.redis.common.config.JedisClusterConfig;
 import org.apache.storm.redis.common.config.JedisPoolConfig;
@@ -14,15 +10,12 @@ import org.apache.storm.tuple.Values;
 import redis.clients.jedis.JedisCommands;
 import redis.clients.jedis.Jedis;
 
-import java.sql.Timestamp;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
-
 
 public class RedisAverageQueryBolt extends AbstractRedisBolt {
 
-    JedisPoolConfig config;
+    private JedisPoolConfig config;
 
     public RedisAverageQueryBolt(JedisPoolConfig config) {
         super(config);

--- a/src/main/java/storm/RedisAverageQueryBolt.java
+++ b/src/main/java/storm/RedisAverageQueryBolt.java
@@ -12,6 +12,7 @@ import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.tuple.Values;
 import redis.clients.jedis.JedisCommands;
+import redis.clients.jedis.Jedis;
 
 import java.sql.Timestamp;
 import java.util.HashMap;
@@ -30,6 +31,7 @@ public class RedisAverageQueryBolt extends AbstractRedisBolt {
     }
 
     protected void process(Tuple tuple) {
+        Jedis jedis = new Jedis("redis");
         JedisCommands jedisCommands = null;
         try {
             jedisCommands = getInstance();
@@ -41,6 +43,7 @@ public class RedisAverageQueryBolt extends AbstractRedisBolt {
             update.put(deviceFunc, String.valueOf(deviceData));
 
             jedisCommands.hmset(deviceId, update);
+            jedis.publish(deviceId, "ping");
             collector.emit(new Values(deviceId, deviceFunc, deviceData));
             collector.ack(tuple);
         } catch (Exception e) {

--- a/src/main/java/storm/RedisAverageQueryBolt.java
+++ b/src/main/java/storm/RedisAverageQueryBolt.java
@@ -22,8 +22,11 @@ import java.util.Set;
 
 public class RedisAverageQueryBolt extends AbstractRedisBolt {
 
+    JedisPoolConfig config;
+
     public RedisAverageQueryBolt(JedisPoolConfig config) {
         super(config);
+        this.config = config;
     }
 
     public RedisAverageQueryBolt(JedisClusterConfig config) {
@@ -31,7 +34,7 @@ public class RedisAverageQueryBolt extends AbstractRedisBolt {
     }
 
     protected void process(Tuple tuple) {
-        Jedis jedis = new Jedis("redis");
+        Jedis jedis = new Jedis(config.getHost());
         JedisCommands jedisCommands = null;
         try {
             jedisCommands = getInstance();

--- a/src/main/java/storm/RedisBolt.java
+++ b/src/main/java/storm/RedisBolt.java
@@ -3,7 +3,6 @@ package storm;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 import org.apache.storm.redis.bolt.AbstractRedisBolt;
 import org.apache.storm.redis.common.config.JedisClusterConfig;
 import org.apache.storm.redis.common.config.JedisPoolConfig;
@@ -13,16 +12,14 @@ import org.apache.storm.tuple.Tuple;
 import org.apache.storm.tuple.Values;
 import redis.clients.jedis.JedisCommands;
 import redis.clients.jedis.Jedis;
-import redis.clients.jedis.JedisPool;
 
 import java.sql.Timestamp;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-
 public class RedisBolt extends AbstractRedisBolt {
-    JedisPoolConfig config;
+    private JedisPoolConfig config;
 
     public RedisBolt(JedisPoolConfig config) {
         super(config);

--- a/src/main/java/storm/RedisBolt.java
+++ b/src/main/java/storm/RedisBolt.java
@@ -12,6 +12,7 @@ import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.tuple.Values;
 import redis.clients.jedis.JedisCommands;
+import redis.clients.jedis.Jedis;
 
 import java.sql.Timestamp;
 import java.util.HashMap;
@@ -30,6 +31,7 @@ public class RedisBolt extends AbstractRedisBolt {
     }
 
     protected void process(Tuple tuple) {
+        Jedis jedis = new Jedis("redis");
         JedisCommands jedisCommands = null;
         try {
             jedisCommands = getInstance();
@@ -50,6 +52,7 @@ public class RedisBolt extends AbstractRedisBolt {
             });
 
             jedisCommands.hmset(String.valueOf(deviceId), update);
+            jedis.publish(deviceId, "ping");
             collector.emit(new Values(deviceId, deviceData, deviceTimestamp));
             collector.ack(tuple);
         } catch (Exception e) {

--- a/src/main/java/storm/RedisBolt.java
+++ b/src/main/java/storm/RedisBolt.java
@@ -13,6 +13,7 @@ import org.apache.storm.tuple.Tuple;
 import org.apache.storm.tuple.Values;
 import redis.clients.jedis.JedisCommands;
 import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
 
 import java.sql.Timestamp;
 import java.util.HashMap;
@@ -21,9 +22,11 @@ import java.util.Set;
 
 
 public class RedisBolt extends AbstractRedisBolt {
+    JedisPoolConfig config;
 
     public RedisBolt(JedisPoolConfig config) {
         super(config);
+        this.config = config;
     }
 
     public RedisBolt(JedisClusterConfig config) {
@@ -31,10 +34,11 @@ public class RedisBolt extends AbstractRedisBolt {
     }
 
     protected void process(Tuple tuple) {
-        Jedis jedis = new Jedis("redis");
+        Jedis jedis = new Jedis(config.getHost());
         JedisCommands jedisCommands = null;
         try {
             jedisCommands = getInstance();
+
             Gson gson = new Gson();
             JsonObject json = gson.fromJson(tuple.getString(0), JsonObject.class);
 


### PR DESCRIPTION
Publish a "ping" to the deviceId channel when data comes in. When we see that in the node server, we can then get the data stored at that key. This is because redis can only send strings through pubsub.

We could send a JSON object as a string through if we want to. Any thoughts on this?